### PR TITLE
Allow publishing of golden ID updates from JeMPI to Kafka

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpi-mediator",
-  "version": "1.0.0",
+  "version": "v1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mpi-mediator",
-      "version": "1.0.0",
+      "version": "v1.1.0",
       "license": "ISC",
       "dependencies": {
         "@types/sinon": "^10.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpi-mediator",
-  "version": "v1.1.0",
+  "version": "v1.2.0",
   "description": "An OpenHIM mediator to handle all interactions with an MPI component",
   "main": "index.ts",
   "scripts": {
@@ -8,7 +8,7 @@
     "start": "ts-node -r dotenv/config src/index.ts",
     "format": "prettier --check --write '{src,tests}/**/*.ts'",
     "lint": "eslint . --ext .ts,.js --fix",
-    "docker:build": "npm run build; docker build -t jembi/mpi-mediator:v1.1.0 .",
+    "docker:build": "npm run build; docker build -t jembi/mpi-mediator:latest .",
     "build": "npm install; tsc -p tsconfig.build.json",
     "test:unit": "LOG_LEVEL='fatal' MODE='testing' mocha -r ts-node/register 'tests/unit/*.ts' --timeout 15000",
     "test:cucumber": "CUCUMBER_DEFAULT_TIMEOUT=20000 MODE='testing' cucumber-js 'tests/cucumber/features/**/*.feature' --no-color --exit --logLevel='error' --require 'tests/cucumber/step-definitions/*.ts' --require-module 'ts-node/register' --require-module 'dotenv/config' dotenv_config_path=.env.test --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format summary --format progress-bar",
@@ -57,11 +57,11 @@
   },
   "dependencies": {
     "@types/sinon": "^10.0.13",
+    "date-fns": "^2.29.3",
     "express": "^4.18.2",
     "express-async-handler": "^1.2.0",
-    "kafkajs": "^2.2.2",
-    "date-fns": "^2.29.3",
     "http-proxy-middleware": "^2.0.6",
+    "kafkajs": "^2.2.2",
     "node-fetch": "^2.6.7",
     "openhim-mediator-utils": "^0.2.4",
     "pino": "^8.7.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -28,6 +28,7 @@ export const getConfig = () => {
     kafkaBundleTopic: process.env.KAFKA_BUNDLE_TOPIC || '2xx',
     kafkaAsyncBundleTopic: process.env.KAFKA_ASYNC_BUNDLE_TOPIC || '2xx-async',
     kafkaErrorTopic: process.env.KAFKA_ERROR_TOPIC || 'errors',
+    kafkaPatientTopic: process.env.KAFKA_PATIENT_TOPIC ?? 'patient',
     mpiKafkaClientId: process.env.MPI_KAFKA_CLIENT_ID || 'mpi-mediator',
     runningMode: process.env.MODE || '',
     mpiHost: process.env.MPI_HOST || 'santedb-mpi',
@@ -36,7 +37,11 @@ export const getConfig = () => {
     mpiAuthEnabled: process.env.MPI_AUTH_ENABLED === 'false' ? false : true,
     mpiClientId: process.env.MPI_CLIENT_ID || '',
     mpiClientSecret: process.env.MPI_CLIENT_SECRET || '',
+    mpiProxyUrl: process.env.MPI_PROXY_URL || '',
     cucumberDefaultTimeout: process.env.CUCUMBER_DEFAULT_TIMEOUT || 20000,
-    disableValidation: process.env.DISABLE_VALIDATION == 'true' ? true : false
+    disableValidation: process.env.DISABLE_VALIDATION == 'true' ? true : false,
+    enableJempiGoldenIdUpdate:
+      process.env.ENABLE_JEMPI_GOLDEN_ID_UPDATE == 'true' ? true : false,
+    kafkaJempiAuditTopic: process.env.KAFKA_JEMPI_AUDIT_TOPIC ?? 'JeMPI-audit-trail',
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import logger from './logger';
 import routes from './routes/index';
 import { asyncPatientMatchHandler } from './routes/handlers/kafkaAsyncPatientHandler';
 import { setupMediator } from './openhim/openhim';
+import { asyncGoldenIdUpdater } from './routes/handlers/kafkaAsyncGoldenIdUpdater';
 
 const config = getConfig();
 const app = express();
@@ -18,6 +19,11 @@ if (config.runningMode !== 'testing') {
     if (config.registerMediator) {
       setupMediator(path.resolve(__dirname, './openhim/mediatorConfig.json'));
     }
+
     asyncPatientMatchHandler();
+
+    if (config.enableJempiGoldenIdUpdate) {
+      asyncGoldenIdUpdater();
+    }
   });
 }

--- a/src/openhim/mediatorConfig.json
+++ b/src/openhim/mediatorConfig.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:mediator:mpi-mediator",
-  "version": "v1.1.0",
+  "version": "v1.2.0",
   "name": "MPI mediator",
   "description": "A mediator handling interactions between the OpenHIM Core service, Sante MPI, Hapi-FHIR, and Kafka",
   "defaultChannelConfig": [

--- a/src/routes/handlers/kafkaAsyncGoldenIdUpdater.ts
+++ b/src/routes/handlers/kafkaAsyncGoldenIdUpdater.ts
@@ -37,7 +37,15 @@ export const asyncGoldenIdUpdater = async (): Promise<void> => {
         return;
       }
 
-      const audit: JempiAudit = JSON.parse(message.value.toString());
+      let audit: JempiAudit;
+
+      try {
+        audit = JSON.parse(message.value.toString());
+      } catch (error) {
+        logger.error('Error parsing JeMPI audit message', error);
+
+        return;
+      }
 
       if (
         audit.event.startsWith('Interaction -> update GoldenID') ||

--- a/src/routes/handlers/kafkaAsyncGoldenIdUpdater.ts
+++ b/src/routes/handlers/kafkaAsyncGoldenIdUpdater.ts
@@ -1,0 +1,96 @@
+import { Kafka, logLevel } from 'kafkajs';
+
+import { getConfig } from '../../config/config';
+import logger from '../../logger';
+import { JempiAudit } from '../../types/jempiAudit';
+import { fetchMpiResourceByRef } from '../../utils/mpi';
+import { Patient } from 'fhir/r3';
+
+export const asyncGoldenIdUpdater = async (): Promise<void> => {
+  const config = getConfig();
+
+  const kafka = new Kafka({
+    logLevel: logLevel.ERROR,
+    clientId: config.mpiKafkaClientId,
+    brokers: config.kafkaBrokers.split(','),
+  });
+
+  const consumer = kafka.consumer({ groupId: 'mpi-mediator-golden-id' });
+  const producer = kafka.producer();
+
+  await consumer.connect();
+  await consumer.subscribe({
+    topic: config.kafkaJempiAuditTopic,
+  });
+
+  await producer.connect();
+
+  logger.info('Kafka golden ID consumer started');
+
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      logger.info('JeMPI audit received from queue');
+
+      if (message.value === null) {
+        logger.info('JeMPI audit message is null');
+
+        return;
+      }
+
+      const audit: JempiAudit = JSON.parse(message.value.toString());
+
+      if (
+        audit.event.startsWith('Interaction -> update GoldenID') ||
+        audit.event.startsWith('Interaction -> new GoldenID')
+      ) {
+        logger.info(
+          `Received JeMPI audit for a GoldenID change: Updating patientId ${audit.interactionID} with goldenId ${audit.goldenID}`
+        );
+
+        try {
+          const resource = await fetchMpiResourceByRef<Patient>(
+            `Patient/${audit.interactionID}`
+          );
+
+          if (!resource) {
+            logger.error(`Patient with id ${audit.interactionID} not found in MPI`);
+
+            return;
+          }
+
+          if (!resource.link) {
+            resource.link = [];
+          }
+
+          const goldenIdLink = resource.link.find((link) => link.type === 'refer');
+
+          if (goldenIdLink) {
+            goldenIdLink.other = {
+              reference: `Patient/${audit.goldenID}`,
+            };
+          } else {
+            resource.link.push({
+              type: 'refer',
+              other: {
+                reference: `Patient/${audit.goldenID}`,
+              },
+            });
+          }
+
+          await producer.send({
+            topic: config.kafkaPatientTopic,
+            messages: [
+              {
+                value: JSON.stringify({
+                  resource,
+                }),
+              },
+            ],
+          });
+        } catch (err) {
+          logger.error(`Error sending patient to '${config.kafkaPatientTopic}' topic`, err);
+        }
+      }
+    },
+  });
+};

--- a/src/routes/handlers/kafkaAsyncPatientHandler.ts
+++ b/src/routes/handlers/kafkaAsyncPatientHandler.ts
@@ -20,7 +20,6 @@ export const asyncPatientMatchHandler = async (): Promise<void> => {
   await consumer.connect();
   await consumer.subscribe({
     topic: config.kafkaAsyncBundleTopic,
-    fromBeginning: true,
   });
 
   logger.info('Kafka consumer started');

--- a/src/types/jempiAudit.ts
+++ b/src/types/jempiAudit.ts
@@ -1,0 +1,6 @@
+export interface JempiAudit {
+  createdAt: string;
+  interactionID: string;
+  goldenID: string;
+  event: string;
+}

--- a/src/utils/kafkaFhir.ts
+++ b/src/utils/kafkaFhir.ts
@@ -222,12 +222,14 @@ export const processBundle = async (bundle: Bundle): Promise<MpiMediatorResponse
 
   //Add the patient's managing organization and extensions
   let transformedPatient = Object.assign({}, clientRegistryResponse.body);
+
   if (patientResource) {
     if (patientMpiTransformResult.extension?.length) {
       transformedPatient = Object.assign({}, transformedPatient, {
         extension: patientMpiTransformResult.extension,
       });
     }
+
     if (patientMpiTransformResult.managingOrganization) {
       transformedPatient = Object.assign({}, transformedPatient, {
         managingOrganization: patientMpiTransformResult.managingOrganization,

--- a/src/utils/mpi.ts
+++ b/src/utils/mpi.ts
@@ -6,6 +6,10 @@ import { ClientOAuth2, OAuth2Token } from './client-oauth2';
 // Singleton instance of MPI Token stored in memory
 export let mpiToken: OAuth2Token | null = null;
 
+export const resetMpiToken = () => {
+  mpiToken = null;
+};
+
 /**
  * Returns an instance of MPI token, it does renew the token when expired.
  */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -185,7 +185,7 @@ export const modifyBundle = (
  * This method removes the patient's extension and managing organization. The Client registry only stores Patient resources. Extensions and Managing Organization
  * references will result in validation errors.
  * The function returns a tranformed patient, extension and managing organization.
-*/
+ */
 export const transformPatientResourceForMPI = (patient: Resource): MpiTransformResult => {
   const transformedPatient = JSON.parse(JSON.stringify(patient));
 
@@ -203,6 +203,10 @@ export const transformPatientResourceForMPI = (patient: Resource): MpiTransformR
 };
 
 export const createNewPatientRef = (patientId: string): string => {
+  if (config.mpiProxyUrl) {
+    return `${config.mpiProxyUrl}/fhir/Patient/${patientId}`;
+  }
+
   return `${config.mpiProtocol}://${config.mpiHost}:${config.mpiPort}/fhir/Patient/${patientId}`;
 };
 

--- a/tests/unit/kafkaAsyncGoldenIdUpdater.ts
+++ b/tests/unit/kafkaAsyncGoldenIdUpdater.ts
@@ -1,0 +1,157 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import nock from 'nock';
+import { Kafka } from 'kafkajs';
+import { asyncGoldenIdUpdater } from '../../src/routes/handlers/kafkaAsyncGoldenIdUpdater';
+import { getConfig } from '../../src/config/config';
+import logger from '../../src/logger';
+import { resetMpiToken } from '../../src/utils/mpi';
+
+const config = getConfig();
+
+const { mpiProtocol, mpiHost, mpiPort } = config;
+const mpiUrl = `${mpiProtocol}://${mpiHost}:${mpiPort}`;
+
+const oAuthToken = {
+  token_type: 'bearer',
+  access_token: 'accessToken',
+  refresh_token: 'refreshToken',
+  expires_in: 3, // 3s
+};
+
+describe('asyncGoldenIdUpdater', () => {
+  let sandbox: sinon.SinonSandbox;
+  let mockConsumer: any;
+  let mockProducer: any;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockConsumer = {
+      connect: sandbox.stub(),
+      subscribe: sandbox.stub(),
+      run: sandbox.stub(),
+    };
+    mockProducer = {
+      connect: sandbox.stub(),
+      send: sandbox.stub(),
+    };
+    sandbox.stub(Kafka.prototype, 'consumer').returns(mockConsumer);
+    sandbox.stub(Kafka.prototype, 'producer').returns(mockProducer);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+    resetMpiToken();
+  });
+
+  it('should connect to Kafka consumer and producer', async () => {
+    await asyncGoldenIdUpdater();
+    expect(mockConsumer.connect.calledOnce).to.be.true;
+    expect(mockProducer.connect.calledOnce).to.be.true;
+  });
+
+  it('should subscribe to the correct topic', async () => {
+    const config = getConfig();
+    await asyncGoldenIdUpdater();
+    expect(
+      mockConsumer.subscribe.calledWith({
+        topic: config.kafkaJempiAuditTopic,
+      })
+    ).to.be.true;
+  });
+
+  it('should handle message correctly', async () => {
+    const config = getConfig();
+    const mockMessage = {
+      value: JSON.stringify({
+        event: 'Interaction -> update GoldenID',
+        interactionID: 'xxx',
+        goldenID: 'ggg',
+      }),
+    };
+    const mockResource = {
+      link: [],
+    };
+
+    nock(mpiUrl).post('/auth/oauth2_token').reply(200, oAuthToken);
+    nock(mpiUrl).get('/fhir/Patient/xxx').reply(200, mockResource);
+
+    await asyncGoldenIdUpdater();
+    const promises = mockConsumer.run.yieldTo('eachMessage', { message: mockMessage });
+    await promises[0];
+
+    expect(mockProducer.send.calledOnce).to.be.true;
+
+    expect(
+      mockProducer.send.calledWith({
+        topic: config.kafkaPatientTopic,
+        messages: [
+          {
+            value: JSON.stringify({
+              resource: {
+                link: [
+                  {
+                    type: 'refer',
+                    other: {
+                      reference: `Patient/ggg`,
+                    },
+                  },
+                ],
+              },
+            }),
+          },
+        ],
+      })
+    ).to.be.true;
+  });
+
+  it('should handle patient not found error correctly', async () => {
+    const mockMessage = {
+      value: JSON.stringify({
+        event: 'Interaction -> update GoldenID',
+        interactionID: 'xxx',
+        goldenID: 'ggg',
+      }),
+    };
+    const mockError = new Error('Test error');
+    nock(mpiUrl).post(`/auth/oauth2_token`).reply(200, oAuthToken);
+    nock(mpiUrl).get(`/fhir/Patient/xxx`).replyWithError(mockError);
+
+    const loggerErrorStub = sandbox.stub(logger, 'error');
+
+    await asyncGoldenIdUpdater();
+    const promises = mockConsumer.run.yieldTo('eachMessage', { message: mockMessage });
+    await promises[0];
+
+    expect(loggerErrorStub.calledOnce).to.be.true;
+    expect(loggerErrorStub.calledWith(`Patient with id xxx not found in MPI`)).to.be.true;
+  });
+
+  it('should handle producer error correctly', async () => {
+    const mockMessage = {
+      value: JSON.stringify({
+        event: 'Interaction -> update GoldenID',
+        interactionID: 'xxx',
+        goldenID: 'ggg',
+      }),
+    };
+    const mockResource = {
+      link: [],
+    };
+    const mockError = new Error('Test error');
+    nock(mpiUrl).post(`/auth/oauth2_token`).reply(200, oAuthToken);
+    nock(mpiUrl).get('/fhir/Patient/xxx').reply(200, mockResource);
+    mockProducer.send.throws(mockError);
+
+    const loggerErrorStub = sandbox.stub(logger, 'error');
+
+    await asyncGoldenIdUpdater();
+    const promises = mockConsumer.run.yieldTo('eachMessage', { message: mockMessage });
+    await promises[0];
+
+    expect(loggerErrorStub.calledOnce).to.be.true;
+    expect(loggerErrorStub.calledWith(`Error sending patient to 'patient' topic`, mockError))
+      .to.be.true;
+  });
+});

--- a/tests/unit/kafkaAsyncGoldenIdUpdater.ts
+++ b/tests/unit/kafkaAsyncGoldenIdUpdater.ts
@@ -106,6 +106,18 @@ describe('asyncGoldenIdUpdater', () => {
     ).to.be.true;
   });
 
+  it('should handle message with invalid JSON', async () => {
+    const mockMessage = "I'm not JSON";
+    const loggerErrorStub = sandbox.stub(logger, 'error');
+
+    await asyncGoldenIdUpdater();
+    const promises = mockConsumer.run.yieldTo('eachMessage', { message: mockMessage });
+    await promises[0];
+
+    expect(loggerErrorStub.calledOnce).to.be.true;
+    expect(loggerErrorStub.calledWith(`Error parsing JeMPI audit message`)).to.be.true;
+  });
+
   it('should handle patient not found error correctly', async () => {
     const mockMessage = {
       value: JSON.stringify({

--- a/tests/unit/middlewares.ts
+++ b/tests/unit/middlewares.ts
@@ -8,7 +8,6 @@ import { mpiMdmEverythingMiddleware } from '../../src/middlewares/mpi-mdm-everyt
 import { mpiMdmQueryLinksMiddleware } from '../../src/middlewares/mpi-mdm-query-links';
 import { validationMiddleware } from '../../src/middlewares/validation';
 import { mpiAuthMiddleware } from '../../src/middlewares/mpi-auth';
-import format from 'date-fns/format';
 
 const config = getConfig();
 


### PR DESCRIPTION
This pull request enables the publishing of golden ID updates from JeMPI to Kafka. It includes the following commits:

- Allow publishing of golden ID updates from JeMPI to Kafka

- Don't read from the beginning every time else we will reprocess everything every restart

- Allow a different URL to be returned if the MPI is behind a proxy i.e. OpenHIM

The `asyncGoldenIdUpdater` function listens for JeMPI audit messages related to golden ID changes and updates the corresponding patient resource with the new golden ID and pushes it to Kafka for systems to react to.
