### PR TITLE
TB-401 add indices false param to the qs.stringify function.

### DIFF
--- a/src/middlewares/fhir-datastore-access-proxy.ts
+++ b/src/middlewares/fhir-datastore-access-proxy.ts
@@ -43,7 +43,8 @@ const createFhirAccessProxy = (): RequestHandler => {
     logProvider,
     pathRewrite(_path, req) {
       // Re-compute the path, since http-proxy-middleware relies on req.originalUrl
-      return `${req.path}?${qs.stringify(req.query)}`;
+      const queryString = qs.stringify(req.query, { indices: false });
+      return `${req.path}?${queryString}`;
     },
     onError(err, _req, _res) {
       logger.error(err);


### PR DESCRIPTION
This PR fixes a bug where stringifying query params result in an array representation of params with similar keys. 
`
/fhir/Encounter?date=ge2022-08-01&date=le2023-08-30 is converted to date[0]=ge2022-08-01&date[1]=le2023-08-30`
