### PR TITLE
Allow source ID ot be saved as FHIR logical ID, map between source id and interaction id

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -87,7 +87,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
     {}
   );
 
-  let upsteamId = requestedId;
+  let upstreamId = requestedId;
 
   if (fhirResponse.status === 200) {
     const patient = fhirResponse.body as Patient;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -116,7 +116,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
     mpiProtocol,
     mpiHost,
     mpiPort,
-    `/fhir/links/Patient/${upsteamId}`,
+    `/fhir/links/Patient/${upstreamId}`,
     {}
   );
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -95,7 +95,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
       patient.link && patient.link[0]?.other.reference?.match(/Patient\/([^/]+)/)?.[1];
 
     if (interactionId) {
-      upsteamId = interactionId;
+      upstreamId = interactionId;
       logger.debug(`Swapping source ID ${requestedId} for interaction ID ${upsteamId}`);
     }
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -96,7 +96,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
 
     if (interactionId) {
       upstreamId = interactionId;
-      logger.debug(`Swapping source ID ${requestedId} for interaction ID ${upsteamId}`);
+      logger.debug(`Swapping source ID ${requestedId} for interaction ID ${upstreamId}`);
     }
   }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -126,7 +126,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
 
     patient.id = requestedId;
     logger.debug(
-      `Mapped upstream ID ${upsteamId} to requested ID ${requestedId} in response body`
+      `Mapped upstream ID ${upstreamId} to requested ID ${requestedId} in response body`
     );
   }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -100,7 +100,7 @@ routes.get('/fhir/Patient/:patientId', async (req, res) => {
     }
   }
 
-  logger.debug(`Fetching patient ${upsteamId} from MPI`);
+  logger.debug(`Fetching patient ${upstreamId} from MPI`);
 
   const headers: HeadersInit = {
     'Content-Type': 'application/fhir+json',

--- a/src/utils/mpi.ts
+++ b/src/utils/mpi.ts
@@ -89,7 +89,7 @@ export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: str
   );
 
   // Fetch patient links from MPI
-  const mpiPatient = await getData(
+  let mpiPatient = await getData(
     protocol,
     host,
     port,
@@ -98,6 +98,18 @@ export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: str
       .pop()}`,
     headers
   );
+
+  if (!isHttpStatusOk(mpiPatient.status)) {
+    await getData(
+      protocol,
+      host,
+      port,
+      `/fhir/Patient/${Object.assign(guttedPatient.body)
+        .link[0].other.reference.split('/')
+        .pop()}`,
+      headers
+    );
+  }
 
   const links: string[] = Object.assign(mpiPatient.body).link.map(
     (element: { other: { reference: string } }) =>

--- a/src/utils/mpi.ts
+++ b/src/utils/mpi.ts
@@ -61,6 +61,9 @@ export const fetchMpiResourceByRef = async <T extends Resource>(
 };
 
 export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: string[]) => {
+  const patientLinksSet: Set<string> = new Set();
+  patientLinksSet.add(patientRef);
+
   const {
     mpiProtocol: protocol,
     mpiHost: host,
@@ -99,8 +102,9 @@ export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: str
     headers
   );
 
+  // Cater for SanteMpi client registry
   if (!isHttpStatusOk(mpiPatient.status)) {
-    await getData(
+    mpiPatient = await getData(
       protocol,
       host,
       port,
@@ -124,7 +128,8 @@ export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: str
     headers
   );
 
-  Object.assign(guttedPatients.body).entry.forEach((patient: { fullUrl: string }) => {
-    patientLinks.push(patient.fullUrl);
+  Object.assign(guttedPatients.body).entry?.forEach((patient: { fullUrl: string }) => {
+    patientLinksSet.add(patient.fullUrl);
   });
+  patientLinks.push(...patientLinksSet);
 };

--- a/src/utils/mpi.ts
+++ b/src/utils/mpi.ts
@@ -1,6 +1,6 @@
 import { Patient, Resource } from 'fhir/r3';
 import { getConfig } from '../config/config';
-import { getData, isHttpStatusOk } from './utils';
+import { createNewPatientRef, getData, isHttpStatusOk } from './utils';
 import { ClientOAuth2, OAuth2Token } from './client-oauth2';
 
 // Singleton instance of MPI Token stored in memory
@@ -60,24 +60,59 @@ export const fetchMpiResourceByRef = async <T extends Resource>(
   return isHttpStatusOk(response.status) ? (response.body as T) : undefined;
 };
 
-/**
- * Recursively fetch linked patient refs from the MPI
- */
 export const fetchMpiPatientLinks = async (patientRef: string, patientLinks: string[]) => {
-  patientLinks.push(patientRef);
+  const {
+    mpiProtocol: protocol,
+    mpiHost: host,
+    mpiPort: port,
+    mpiAuthEnabled,
+    fhirDatastoreHost,
+    fhirDatastorePort,
+    fhirDatastoreProtocol,
+  } = getConfig();
+  const headers: HeadersInit = {
+    'Content-Type': 'application/fhir+json',
+  };
 
-  const patient = await fetchMpiResourceByRef<Patient>(patientRef);
+  if (mpiAuthEnabled) {
+    const token = await getMpiAuthToken();
 
-  if (patient?.link) {
-    const linkedRefs = patient.link.map(({ other }) => other.reference);
-    const refsToFetch = linkedRefs.filter((ref) => {
-      return ref && !patientLinks.includes(ref);
-    }) as string[];
-
-    if (refsToFetch.length > 0) {
-      const promises = refsToFetch.map((ref) => fetchMpiPatientLinks(ref, patientLinks));
-
-      await Promise.all(promises);
-    }
+    headers['Authorization'] = `Bearer ${token.accessToken}`;
   }
+
+  const guttedPatient = await getData(
+    fhirDatastoreProtocol,
+    fhirDatastoreHost,
+    fhirDatastorePort,
+    `/fhir/${patientRef}`,
+    headers
+  );
+
+  // Fetch patient links from MPI
+  const mpiPatient = await getData(
+    protocol,
+    host,
+    port,
+    `/fhir/links/Patient/${Object.assign(guttedPatient.body)
+      .link[0].other.reference.split('/')
+      .pop()}`,
+    headers
+  );
+
+  const links: string[] = Object.assign(mpiPatient.body).link.map(
+    (element: { other: { reference: string } }) =>
+      createNewPatientRef(element.other.reference.split('/').pop() || '')
+  );
+
+  const guttedPatients = await getData(
+    fhirDatastoreProtocol,
+    fhirDatastoreHost,
+    fhirDatastorePort,
+    `/fhir/Patient?link=${encodeURIComponent(links.join(','))}`,
+    headers
+  );
+
+  Object.assign(guttedPatients.body).entry.forEach((patient: { fullUrl: string }) => {
+    patientLinks.push(patient.fullUrl);
+  });
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -163,6 +163,7 @@ export const modifyBundle = (
         fullUrl: entry.fullUrl,
         resource: {
           resourceType: 'Patient',
+          id: entry.resource.id,
           link: [
             {
               other: {
@@ -174,7 +175,7 @@ export const modifyBundle = (
         },
         request: {
           method: 'PUT',
-          url: `Patient/${newPatientId}`,
+          url: `Patient/${entry.resource.id}`,
         },
       };
 

--- a/tests/cucumber/features/fhirAccessProxy.feature
+++ b/tests/cucumber/features/fhirAccessProxy.feature
@@ -3,7 +3,8 @@ Feature: FHIR Access Proxy
 
   Scenario: Valid $everything Request
     Given MPI and FHIR services are up and running
-    When an $everything search request is sent
+    When there is data
+    And an $everything search request is sent
     Then a successful response containing a bundle of related patient resources is sent back
 
   Scenario: Valid $everything Request without MDM

--- a/tests/cucumber/step-definitions/fhirAccessProxy.ts
+++ b/tests/cucumber/step-definitions/fhirAccessProxy.ts
@@ -29,6 +29,16 @@ Given('MPI and FHIR services are up and running', async (): Promise<void> => {
   request = supertest(server);
 });
 
+When('there is data', async (): Promise<void> => {
+  const response = await request
+    .post('/fhir')
+    .send(bundle)
+    .set('content-type', 'application/fhir+json')
+    .expect(200);
+
+  responseBody = response.body;
+});
+
 When('an $everything search request is sent', async (): Promise<void> => {
   const response = await request
     .get('/fhir/Patient/testPatient/$everything?_mdm=true')

--- a/tests/cucumber/step-definitions/fhirAccessProxy.ts
+++ b/tests/cucumber/step-definitions/fhirAccessProxy.ts
@@ -31,7 +31,7 @@ Given('MPI and FHIR services are up and running', async (): Promise<void> => {
 
 When('an $everything search request is sent', async (): Promise<void> => {
   const response = await request
-    .get('/fhir/Patient/1/$everything?_mdm=true')
+    .get('/fhir/Patient/testPatient/$everything?_mdm=true')
     .set('Content-Type', 'application/fhir+json')
     .expect(200);
   responseBody = response.body;
@@ -77,7 +77,7 @@ Then('a successful response containing a bundle is sent back', (): void => {
 
 When('an MDM search request is sent', async (): Promise<void> => {
   const response = await request
-    .get('/fhir/Observation?subject:mdm=Patient/1')
+    .get('/fhir/Observation?subject:mdm=Patient/testPatient')
     .set('Content-Type', 'application/fhir+json')
     .expect(200);
 

--- a/tests/cucumber/step-definitions/patientSyncMatching.ts
+++ b/tests/cucumber/step-definitions/patientSyncMatching.ts
@@ -103,8 +103,20 @@ Then('a patient should be created on the client registry', async (): Promise<voi
 
   const patientId = response.location.split('/')[1];
 
+  const fhirPatient = await fetch(
+    `${config.fhirDatastoreProtocol}://${config.fhirDatastoreHost}:${config.fhirDatastorePort}/fhir/Patient/${patientId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${auth.accessToken}`,
+      },
+      method: 'GET',
+    }
+  );
+
+  const jsonPatient = await fhirPatient.json()
+
   const res = await fetch(
-    `${config.mpiProtocol}://${config.mpiHost}:${config.mpiPort}/fhir/Patient/${patientId}`,
+    jsonPatient.link[0].other.reference,
     {
       headers: {
         Authorization: `Bearer ${auth.accessToken}`,

--- a/tests/unit/matchPatientSync.ts
+++ b/tests/unit/matchPatientSync.ts
@@ -343,9 +343,10 @@ describe('Match Patient Synchronously', (): void => {
             fullUrl: 'Patient/12333',
             request: {
               method: 'PUT',
-              url: 'Patient/testPatient',
+              url: 'Patient/12333',
             },
             resource: {
+              id: '12333',
               link: [
                 {
                   other: {

--- a/tests/unit/middlewares.ts
+++ b/tests/unit/middlewares.ts
@@ -9,6 +9,7 @@ import { mpiMdmQueryLinksMiddleware } from '../../src/middlewares/mpi-mdm-query-
 import { validationMiddleware } from '../../src/middlewares/validation';
 import { mpiAuthMiddleware } from '../../src/middlewares/mpi-auth';
 import { mpiMdmSummaryMiddleware } from '../../src/middlewares/mpi-mdm-summary';
+import { createNewPatientRef } from '../../src/utils/utils';
 
 const config = getConfig();
 
@@ -31,7 +32,7 @@ const patientFhirResource1: Patient = {
   link: [
     {
       other: {
-        reference: 'Patient/2',
+        reference: 'Patient/0x4',
       },
       type: 'refer',
     },
@@ -44,7 +45,7 @@ const patientFhirResource2: Patient = {
   link: [
     {
       other: {
-        reference: 'Patient/1',
+        reference: 'Patient/0x7',
       },
       type: 'seealso',
     },
@@ -324,8 +325,11 @@ describe('Middlewares', (): void => {
 
     it('should perform MDM expansion when mdm param is supplied', async () => {
       nock(mpiUrl).persist().post('/auth/oauth2_token').reply(200, newOauth2TokenGenerated);
-      nock(mpiUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
+      nock(mpiUrl).get('/fhir/links/Patient/0x4').reply(200, {...patientFhirResource1, link: [{other: {reference: 'Patient/0x4'}}, {other: {reference: 'Patient/0x7'}}]});
       nock(mpiUrl).get('/fhir/Patient/2').reply(200, patientFhirResource2);
+      const links = encodeURIComponent([createNewPatientRef('0x4'),createNewPatientRef('0x7')].join(','))
+      nock(fhirDatastoreUrl).get(`/fhir/Patient?link=${links}`).reply(200, {entry: [{fullUrl: 'Patient/1'}, {fullUrl: 'Patient/2'}]});
+      nock(fhirDatastoreUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
       nock(fhirDatastoreUrl)
         .get(`/fhir/Encounter?subject=${encodeURIComponent('Patient/1,Patient/2')}`)
         .reply(200, Encounters);
@@ -383,8 +387,11 @@ describe('Middlewares', (): void => {
 
     it('should preform MDM expansion when mdm param is supplied', async () => {
       nock(mpiUrl).persist().post('/auth/oauth2_token').reply(200, newOauth2TokenGenerated);
-      nock(mpiUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
+      nock(mpiUrl).get('/fhir/links/Patient/0x4').reply(200, {...patientFhirResource1, link: [{other: {reference: 'Patient/0x4'}}, {other: {reference: 'Patient/0x7'}}]});
       nock(mpiUrl).get('/fhir/Patient/2').reply(200, patientFhirResource2);
+      const links = encodeURIComponent([createNewPatientRef('0x4'),createNewPatientRef('0x7')].join(','))
+      nock(fhirDatastoreUrl).get(`/fhir/Patient?link=${links}`).reply(200, {entry: [{fullUrl: 'Patient/1'}, {fullUrl: 'Patient/2'}]});
+      nock(fhirDatastoreUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
       nock(fhirDatastoreUrl)
         .get(`/fhir/${patientRefSummary1}/$summary`)
         .reply(200, patientSummary1);
@@ -435,8 +442,12 @@ describe('Middlewares', (): void => {
 
     it('should perform MDM expansion when mdm param is supplied', async () => {
       nock(mpiUrl).persist().post('/auth/oauth2_token').reply(200, {});
-      nock(mpiUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
+      nock(mpiUrl).get('/fhir/links/Patient/0x4').reply(200, {...patientFhirResource1, link: [{other: {reference: 'Patient/0x4'}}, {other: {reference: 'Patient/0x7'}}]});
       nock(mpiUrl).get('/fhir/Patient/2').reply(200, patientFhirResource2);
+      const links = encodeURIComponent([createNewPatientRef('0x4'),createNewPatientRef('0x7')].join(','))
+      nock(fhirDatastoreUrl).get(`/fhir/Patient?link=${links}`).reply(200, {entry: [{fullUrl: 'Patient/1'}, {fullUrl: 'Patient/2'}]});
+      nock(fhirDatastoreUrl).get('/fhir/Patient/1').reply(200, patientFhirResource1);
+
       const request = {
         body: {},
         headers: {},

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -359,6 +359,7 @@ describe('Utils', (): void => {
             fullUrl: 'Patient/1234',
             resource: {
               resourceType: 'Patient',
+              id: '1233',
               link: [
                 {
                   type: 'refer',
@@ -370,7 +371,7 @@ describe('Utils', (): void => {
             },
             request: {
               method: 'PUT',
-              url: 'Patient/xxx',
+              url: 'Patient/1233',
             },
           },
         ],
@@ -473,6 +474,7 @@ describe('Utils', (): void => {
                 profile: ['http://example.com/patient-profile'],
               },
               resourceType: 'Patient',
+              id: '1233',
               link: [
                 {
                   type: 'refer',
@@ -484,7 +486,7 @@ describe('Utils', (): void => {
             },
             request: {
               method: 'PUT',
-              url: 'Patient/xxx',
+              url: 'Patient/1233',
             },
           },
         ],


### PR DESCRIPTION
This pull request adds functionality to save by source ID and swaps the source ID for the interaction ID in the FHIR Patient endpoint.

To use this OpenHIM channels must also be edited. The JeMPI channel patttern must be changed to `/fhir/Patient\??[^/]*` to allow the MPI mediator to handle `/Patient/<surceId>` queries.

This change has also been push to a temporary tag on docker hub for testing: `sl-conn`