### PR TITLE
Hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mpi-mediator",
-  "version": "v2.1.0",
+  "version": "v2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mpi-mediator",
-      "version": "v2.1.0",
+      "version": "v2.1.1",
       "license": "ISC",
       "dependencies": {
         "@types/sinon": "^10.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpi-mediator",
-  "version": "v2.1.0",
+  "version": "v2.1.1",
   "description": "An OpenHIM mediator to handle all interactions with an MPI component",
   "main": "index.ts",
   "scripts": {

--- a/src/utils/kafkaFhir.ts
+++ b/src/utils/kafkaFhir.ts
@@ -80,7 +80,7 @@ export const sendToFhirAndKafka = async (
 
       if (patientData.restoredPatient && bundle.entry) {
         const patientEntry: BundleEntry = {
-          fullUrl: fullUrl,
+          fullUrl,
           resource: patientData.restoredPatient,
           request: {
             method: 'PUT',

--- a/src/utils/kafkaFhir.ts
+++ b/src/utils/kafkaFhir.ts
@@ -76,6 +76,7 @@ export const sendToFhirAndKafka = async (
     // Restore full patient resources to the bundle for sending to Kafka
     Object.keys(newPatientRef).forEach((fullUrl) => {
       const patientData = newPatientRef[fullUrl];
+      const url = `Patient/${patientData.mpiResponsePatient?.id}`;
 
       if (patientData.restoredPatient && bundle.entry) {
         const patientEntry: BundleEntry = {
@@ -83,7 +84,7 @@ export const sendToFhirAndKafka = async (
           resource: patientData.restoredPatient,
           request: {
             method: 'PUT',
-            url: `Patient/${patientData.mpiResponsePatient?.id}`,
+            url
           },
         };
 
@@ -100,6 +101,13 @@ export const sendToFhirAndKafka = async (
             `Adding restored patient (fullUrl: ${fullUrl}) resource to bundle, no matching entry found`
           );
           bundle.entry.push(patientEntry);
+        }
+
+        // Replace the old patient reference in the resources
+        const oldId = fullUrl.split('/').pop();
+
+        if (oldId) {
+          bundle = JSON.parse(JSON.stringify(bundle).replace(RegExp(`Patient/${oldId}`, 'g'), url));
         }
       }
     });


### PR DESCRIPTION
Replace the old patient reference with the new patient ref (the one created in the client registry). The clinical data was being sent to Clickhouse with old patient ref, resulting in us not being able to link the demographic data and the clinical data in ClickHouse