### PR TITLE
Add orchestrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpi-mediator",
-  "version": "v2.1.1",
+  "version": "v2.2.0",
   "description": "An OpenHIM mediator to handle all interactions with an MPI component",
   "main": "index.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpi-mediator",
-  "version": "v2.2.0",
+  "version": "v2.3.0",
   "description": "An OpenHIM mediator to handle all interactions with an MPI component",
   "main": "index.ts",
   "scripts": {

--- a/src/middlewares/mpi-mdm-everything.ts
+++ b/src/middlewares/mpi-mdm-everything.ts
@@ -25,7 +25,7 @@ const fetchAllLinkedPatientResources = async (
 
     return {
       status: 200,
-      body: buildOpenhimResponseObject('Success', 200, bundle, 'application/fhir+json', orchestrations),
+      body: buildOpenhimResponseObject('Successful', 200, bundle, 'application/fhir+json', orchestrations),
     };
   } catch (e) {
     logger.error('Unable to fetch all linked patient resources (MDM expansion)', e);

--- a/src/middlewares/mpi-mdm-everything.ts
+++ b/src/middlewares/mpi-mdm-everything.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express';
 import logger from '../logger';
 import { buildOpenhimResponseObject } from '../utils/utils';
-import { MpiMediatorResponseObject } from '../types/response';
+import { MpiMediatorResponseObject, Orchestration } from '../types/response';
 import { fetchMpiPatientLinks } from '../utils/mpi';
 import { fetchAllPatientResourcesByRefs } from '../routes/handlers/fetchPatientResources';
 
@@ -11,6 +11,8 @@ import { fetchAllPatientResourcesByRefs } from '../routes/handlers/fetchPatientR
 const fetchAllLinkedPatientResources = async (
   patientId: string
 ): Promise<MpiMediatorResponseObject> => {
+  const orchestrations: Orchestration[] = [];
+
   try {
     const patientRef = `Patient/${patientId}`;
     const patientRefs: string[] = [];
@@ -19,18 +21,18 @@ const fetchAllLinkedPatientResources = async (
     await fetchMpiPatientLinks(patientRef, patientRefs);
 
     // Perform requests to HAPI FHIR to get everything for each patient ref
-    const bundle = await fetchAllPatientResourcesByRefs(patientRefs);
+    const bundle = await fetchAllPatientResourcesByRefs(patientRefs, orchestrations);
 
     return {
       status: 200,
-      body: buildOpenhimResponseObject('Success', 200, bundle),
+      body: buildOpenhimResponseObject('Success', 200, bundle, 'application/fhir+json', orchestrations),
     };
   } catch (e) {
     logger.error('Unable to fetch all linked patient resources (MDM expansion)', e);
 
     return {
       status: 500,
-      body: buildOpenhimResponseObject('Failed', 500, e as Error),
+      body: buildOpenhimResponseObject('Failed', 500, e as Error, 'application/fhir+json', orchestrations),
     };
   }
 };

--- a/src/middlewares/mpi-mdm-summary.ts
+++ b/src/middlewares/mpi-mdm-summary.ts
@@ -3,28 +3,31 @@ import logger from '../logger';
 import { fetchMpiPatientLinks } from '../utils/mpi';
 import { buildOpenhimResponseObject } from '../utils/utils';
 import { fetchAllPatientSummariesByRefs } from '../routes/handlers/fetchPatientSummaries';
+import { Orchestration } from '../types/response';
 
 const fetchAllLinkedPatientSummary = async (patientId: string) => {
+  const orchestrations: Orchestration[] = [];
+
   try {
     const patientRef = `Patient/${patientId}`;
     const patientRefs: string[] = [];
 
     await fetchMpiPatientLinks(patientRef, patientRefs);
 
-    const bundle = await fetchAllPatientSummariesByRefs(patientRefs);
+    const bundle = await fetchAllPatientSummariesByRefs(patientRefs, orchestrations);
 
     logger.debug(`Fetched all patient summaries from the MPI: ${bundle}`);
 
     return {
       status: 200,
-      body: buildOpenhimResponseObject('Success', 200, bundle),
+      body: buildOpenhimResponseObject('Success', 200, bundle, 'application/fhir+json', orchestrations),
     };
   } catch (e) {
     logger.error('Unable to fetch all linked patient resources (MDM expansion)', e);
 
     return {
       status: 500,
-      body: buildOpenhimResponseObject('Failed', 500, e as Error),
+      body: buildOpenhimResponseObject('Failed', 500, e as Error, 'application/fhir+json', orchestrations),
     };
   }
 };

--- a/src/middlewares/mpi-mdm-summary.ts
+++ b/src/middlewares/mpi-mdm-summary.ts
@@ -20,7 +20,7 @@ const fetchAllLinkedPatientSummary = async (patientId: string, params: object) =
 
     return {
       status: 200,
-      body: buildOpenhimResponseObject('Success', 200, bundle, 'application/fhir+json', orchestrations),
+      body: buildOpenhimResponseObject('Successful', 200, bundle, 'application/fhir+json', orchestrations),
     };
   } catch (e) {
     logger.error('Unable to fetch all linked patient resources (MDM expansion)', e);

--- a/src/middlewares/openhim-proxy-interceptor.ts
+++ b/src/middlewares/openhim-proxy-interceptor.ts
@@ -16,7 +16,7 @@ export const openhimProxyResponseInterceptor = responseInterceptor(
 
     if (isHttpStatusOk(statusCode)) {
       logger.info('Successfully proxied request!');
-      transactionStatus = 'Success';
+      transactionStatus = 'Successful';
     } else {
       logger.error(`Error in validating: ${JSON.stringify(body)}!`);
       transactionStatus = 'Failed';

--- a/src/middlewares/validation.ts
+++ b/src/middlewares/validation.ts
@@ -37,7 +37,7 @@ export const validationMiddleware: RequestHandler = async (req, res, next) => {
       { 'Content-Type': 'application/fhir+json' }
     );
 
-    transactionStatus = 'Success';
+    transactionStatus = 'Successful';
 
     if (isHttpStatusOk(response.status)) {
       logger.info('Successfully validated bundle!');

--- a/src/openhim/mediatorConfig.json
+++ b/src/openhim/mediatorConfig.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:mediator:mpi-mediator",
-  "version": "v2.0.0",
+  "version": "v2.2.0",
   "name": "MPI mediator",
   "description": "A mediator handling interactions between the OpenHIM Core service, Sante MPI, Hapi-FHIR, and Kafka",
   "defaultChannelConfig": [

--- a/src/openhim/mediatorConfig.json
+++ b/src/openhim/mediatorConfig.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:mediator:mpi-mediator",
-  "version": "v2.2.0",
+  "version": "v2.3.0",
   "name": "MPI mediator",
   "description": "A mediator handling interactions between the OpenHIM Core service, Sante MPI, Hapi-FHIR, and Kafka",
   "defaultChannelConfig": [

--- a/src/routes/handlers/fetchPatientResources.ts
+++ b/src/routes/handlers/fetchPatientResources.ts
@@ -70,7 +70,7 @@ export const fetchEverythingByRef = async (
   try {
     const bundle = await fetchAllPatientResourcesByRefs([patientRef], orchestrations);
     const responseBody = buildOpenhimResponseObject(
-      'Success',
+      'Successful',
       200,
       bundle,
       'application/fhir+json',

--- a/src/routes/handlers/fetchPatientSummaries.ts
+++ b/src/routes/handlers/fetchPatientSummaries.ts
@@ -4,6 +4,7 @@ import format from 'date-fns/format';
 import { getConfig } from '../../config/config';
 import {
   buildOpenhimResponseObject,
+  createFhirDatastoreOrcherstation,
   getData,
   isHttpStatusOk,
   mergeBundles,
@@ -39,15 +40,7 @@ export const fetchAllPatientSummariesByRefs = async (
 
     const headers: HeadersInit = {'Content-Type': 'application/fhir+json'};
 
-    const orchestration: Orchestration = {
-      name: `Request to fhir datatstore - ${path}`,
-      request: {protocol, host, path, port, method: 'GET', headers, timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")},
-      response: {
-        status: 200,
-        body: '',
-        timestamp: ''
-      }
-    };
+    const orchestration: Orchestration = createFhirDatastoreOrcherstation('Get summary', path);
   
     return getData(protocol, host, port, path, {
       'Content-Type': 'application/fhir+json',

--- a/src/routes/handlers/matchPatientAsync.ts
+++ b/src/routes/handlers/matchPatientAsync.ts
@@ -53,7 +53,7 @@ export const matchAsyncHandler = async (
   logger.info('Fhir bundle successfully sent to Kafka');
 
   return createHandlerResponseObject(
-    'Success',
+    'Successful',
     {
       status: 204,
       body: {},

--- a/src/routes/handlers/matchPatientAsync.ts
+++ b/src/routes/handlers/matchPatientAsync.ts
@@ -1,8 +1,9 @@
 import { Bundle } from 'fhir/r3';
+import format from 'date-fns/format';
+
 import logger from '../../logger';
 import { getConfig } from '../../config/config';
-
-import { MpiMediatorResponseObject } from '../../types/response';
+import { MpiMediatorResponseObject, Orchestration } from '../../types/response';
 import { sendToKafka } from '../../utils/kafkaFhir';
 import { createHandlerResponseObject } from '../../utils/utils';
 
@@ -13,23 +14,50 @@ export const matchAsyncHandler = async (
 ): Promise<MpiMediatorResponseObject> => {
   logger.info('Fhir bundle received for asynchronous matching of the patient!');
 
+  const orchestration: Orchestration = {
+    name: 'Sending to message bus - kafka',
+    request: {
+      host: config.kafkaBrokers,
+      timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+    },
+    response: {
+      status: 200,
+      body: JSON.stringify({ success: true }),
+      timestamp: '',
+      headers: { 'Content-Type': 'application/fhir+json' },
+    },
+  };
+
   const kafkaError = await sendToKafka(bundle, config.kafkaAsyncBundleTopic);
+
+  orchestration.response.timestamp = format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
   if (kafkaError) {
     logger.error(`Error in sending bundle to Kafka patient topic: ${kafkaError.message}`);
 
-    return createHandlerResponseObject('Failed', {
-      body: {
-        error: kafkaError.message,
+    orchestration.response.status = 500;
+    orchestration.response.body = JSON.stringify(kafkaError);
+
+    return createHandlerResponseObject(
+      'Failed',
+      {
+        body: {
+          error: kafkaError.message,
+        },
+        status: 500,
       },
-      status: 500,
-    });
+      [orchestration]
+    );
   }
 
   logger.info('Fhir bundle successfully sent to Kafka');
 
-  return createHandlerResponseObject('Success', {
-    status: 204,
-    body: {},
-  });
+  return createHandlerResponseObject(
+    'Success',
+    {
+      status: 204,
+      body: {},
+    },
+    [orchestration]
+  );
 };

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,14 +1,32 @@
+import { HeaderInit } from "node-fetch";
+
 export interface Response {
   status: number;
   body: string;
   timestamp: string;
-  headers: HeadersInit;
+  headers?: HeadersInit;
 }
 
+export interface Request {
+  protocol?: string;
+  host: string;
+  port?: number | string;
+  path?: string;
+  method?: string;
+  headers?: HeaderInit;
+  body?: string;
+  timestamp: string;
+}
+export interface Orchestration {
+  name: string;
+  request: Request;
+  response: Response;
+}
 export interface OpenHimResponseObject {
   'x-mediator-urn': string;
   status: string;
   response: Response;
+  orchestrations: Orchestration[]
 }
 
 export interface ResponseObject {

--- a/src/utils/kafkaFhir.ts
+++ b/src/utils/kafkaFhir.ts
@@ -1,9 +1,10 @@
 import { Kafka, logLevel } from 'kafkajs';
-
+import format from 'date-fns/format';
 import { Bundle, BundleEntry, Patient } from 'fhir/r3';
+
 import { getConfig } from '../config/config';
 import { RequestDetails } from '../types/request';
-import { MpiMediatorResponseObject, ResponseObject } from '../types/response';
+import { MpiMediatorResponseObject, Orchestration, ResponseObject } from '../types/response';
 import {
   createHandlerResponseObject,
   extractPatientEntries,
@@ -53,9 +54,12 @@ export const sendToKafka = async (bundle: Bundle, topic: string): Promise<Error 
 export const sendToFhirAndKafka = async (
   requestDetails: RequestDetails,
   bundle: Bundle,
-  newPatientRef: NewPatientMap = {}
+  newPatientRef: NewPatientMap = {},
+  orchestrations: Orchestration[] = []
 ): Promise<MpiMediatorResponseObject> => {
   const { protocol, host, port, path, headers } = requestDetails;
+
+  const requestStartTime = format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
   const response: ResponseObject = await postData(
     protocol,
@@ -65,6 +69,27 @@ export const sendToFhirAndKafka = async (
     JSON.stringify(bundle),
     headers
   );
+
+  const orchestration: Orchestration = {
+    name: 'Saving data in Fhir Datastore - hapi-fhir',
+    request: {
+      protocol,
+      host,
+      port,
+      method: 'POST',
+      path,
+      body: JSON.stringify(bundle),
+      headers,
+      timestamp: requestStartTime
+    },
+    response: {
+      status: response.status,
+      body: JSON.stringify(response.body),
+      timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+      headers: {'Content-Type': 'application/fhir+json'}
+    }
+  }
+  orchestrations.push(orchestration);
 
   let transactionStatus: string;
 
@@ -112,10 +137,26 @@ export const sendToFhirAndKafka = async (
       }
     });
 
+    const orchestration: Orchestration = {
+      name: 'Sending to message bus - kafka',
+      request: {
+        host: config.kafkaBrokers,
+        timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({success: true}),
+        timestamp: '',
+        headers: { 'Content-Type': 'application/fhir+json' }
+      }
+    };
+
     const kafkaResponseError: Error | null = await sendToKafka(
       bundle,
       config.kafkaBundleTopic
     );
+
+    orchestration.response.timestamp = format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
     if (kafkaResponseError) {
       logger.error(
@@ -125,9 +166,14 @@ export const sendToFhirAndKafka = async (
       transactionStatus = 'Failed';
       response.body = { kafkaResponseError };
       response.status = 500;
+
+      orchestration.response.status = 500;
+      orchestration.response.body = JSON.stringify(kafkaResponseError);
     } else {
       logger.info('Successfully sent Fhir bundle to Kafka');
     }
+
+    orchestrations.push(orchestration);
   } else {
     logger.error(
       `Error in sending Fhir bundle to Fhir Datastore: ${JSON.stringify(response.body)}!`
@@ -135,7 +181,7 @@ export const sendToFhirAndKafka = async (
     transactionStatus = 'Failed';
   }
 
-  return createHandlerResponseObject(transactionStatus, response);
+  return createHandlerResponseObject(transactionStatus, response, orchestrations);
 };
 
 const clientRegistryRequestDetailsOrg: RequestDetails = {
@@ -185,6 +231,7 @@ export const processBundle = async (bundle: Bundle): Promise<MpiMediatorResponse
   }
 
   const newPatientMap: NewPatientMap = {};
+  const orchestrations: Orchestration[] = [];
 
   // transform and send each patient resource and submit to MPI
   const promises = patientEntries.map(async (patientEntry) => {
@@ -204,11 +251,28 @@ export const processBundle = async (bundle: Bundle): Promise<MpiMediatorResponse
         createHandlerResponseObject('Failed', { status: 400, body: { error } })
       );
     }
-
+    orchestrations.push({
+      name: `Request to Client Registry - ${patientEntry.fullUrl}`,
+      request: {...clientRegistryRequestDetails, timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")},
+      response: {
+        status: 201,
+        body: '',
+        timestamp: ''
+      }
+    })
     return sendRequest(clientRegistryRequestDetails);
   });
 
   const clientRegistryResponses = await Promise.all(promises);
+
+  clientRegistryResponses.forEach((resp, index) => {
+    orchestrations[index].response = {
+      status: resp.status,
+      body: JSON.stringify(resp.body),
+      timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+      headers: { 'Content-Type': 'application/fhir+json' }
+    }
+  });
 
   const failedRequests = clientRegistryResponses.filter(
     (clientRegistryResponse) => !isHttpStatusOk(clientRegistryResponse.status)
@@ -229,7 +293,7 @@ export const processBundle = async (bundle: Bundle): Promise<MpiMediatorResponse
       { status: failedRequests[0].status, body: { errors: [] } }
     );
 
-    return createHandlerResponseObject('Failed', combinedResponse);
+    return createHandlerResponseObject('Failed', combinedResponse, orchestrations);
   }
 
   clientRegistryResponses.map((clientRegistryResponse, index) => {
@@ -252,11 +316,11 @@ export const processBundle = async (bundle: Bundle): Promise<MpiMediatorResponse
   Object.values(newPatientMap).forEach((patientData) => {
     restorePatientResource(patientData);
   });
-
   const handlerResponse: MpiMediatorResponseObject = await sendToFhirAndKafka(
     fhirDatastoreRequestDetails,
     modifiedBundle,
-    newPatientMap
+    newPatientMap,
+    orchestrations
   );
 
   return handlerResponse;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,6 +16,18 @@ import { Bundle, BundleEntry, BundleLink, FhirResource, Patient } from 'fhir/r3'
 import { PatientData } from '../types/newPatientMap';
 
 const config = getConfig();
+const {
+  fhirDatastoreProtocol: fhirProtocol,
+  fhirDatastoreHost: fhirHost,
+  fhirDatastorePort: fhirPort,
+  mpiProtocol,
+  mpiHost,
+  mpiPort
+} = config;
+
+const headers: HeadersInit = {
+  'Content-Type': 'application/fhir+json',
+};
 
 export const isHttpStatusOk = (status: number) => status >= 200 && status < 300;
 
@@ -110,7 +122,7 @@ export const buildOpenhimResponseObject = (
     'x-mediator-urn': config.mediatorUrn,
     status: openhimTransactionStatus,
     response,
-    orchestrations
+    orchestrations,
   };
 };
 
@@ -237,8 +249,8 @@ export const restorePatientResource = (patientData: PatientData) => {
   patientData.restoredPatient = patientData.mpiResponsePatient;
 
   // restore the source uuid of the patient
-  const id = Object.assign({id: ''}, patientData.mpiTransformResult?.patient).id;
-  patientData.restoredPatient = Object.assign({}, patientData.restoredPatient, {id});
+  const id = Object.assign({ id: '' }, patientData.mpiTransformResult?.patient).id;
+  patientData.restoredPatient = Object.assign({}, patientData.restoredPatient, { id });
 
   if (patientData.mpiTransformResult?.extension?.length) {
     patientData.restoredPatient = Object.assign({}, patientData.restoredPatient, {
@@ -323,7 +335,7 @@ export const mergeBundles = async (
   return bundle;
 };
 
-export const patientProjector = (patient: Patient) : Patient => {
+export const patientProjector = (patient: Patient): Patient => {
   return {
     resourceType: patient.resourceType,
     id: patient.id,
@@ -331,5 +343,41 @@ export const patientProjector = (patient: Patient) : Patient => {
     name: patient.name,
     birthDate: patient.birthDate,
     gender: patient.gender
-  }
+  };
 };
+
+export const createFhirDatastoreOrcherstation = (name: string, path: string): Orchestration => ({
+  name: `Request to fhir datastore - ${path} : ${name}`,
+  request: {
+    protocol: fhirProtocol,
+    host: fhirHost,
+    path,
+    port: fhirPort,
+    method: 'GET',
+    headers,
+    timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+  },
+  response: {
+    status: 200,
+    body: '',
+    timestamp: '',
+  },
+});
+
+export const createClientRegistryOrcherstation = (name: string, path: string): Orchestration => ({
+  name: `Request to client registry - ${path} : ${name}`,
+  request: {
+    protocol: mpiProtocol,
+    host: mpiHost,
+    path,
+    port: mpiPort,
+    method: 'GET',
+    headers,
+    timestamp: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"),
+  },
+  response: {
+    status: 200,
+    body: '',
+    timestamp: '',
+  },
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -9,6 +9,7 @@ import {
   Response,
   MpiMediatorResponseObject,
   MpiTransformResult,
+  Orchestration,
 } from '../types/response';
 import { RequestDetails } from '../types/request';
 import { Bundle, BundleEntry, BundleLink, FhirResource, Patient } from 'fhir/r3';
@@ -95,7 +96,8 @@ export const buildOpenhimResponseObject = (
   openhimTransactionStatus: string,
   httpResponseStatusCode: number,
   responseBody: object,
-  contentType = 'application/fhir+json'
+  contentType = 'application/fhir+json',
+  orchestrations: Orchestration[] = []
 ): OpenHimResponseObject => {
   const response: Response = {
     status: httpResponseStatusCode,
@@ -108,6 +110,7 @@ export const buildOpenhimResponseObject = (
     'x-mediator-urn': config.mediatorUrn,
     status: openhimTransactionStatus,
     response,
+    orchestrations
   };
 };
 
@@ -255,12 +258,15 @@ export const createNewPatientRef = (patientId: string): string => {
 
 export const createHandlerResponseObject = (
   transactionStatus: string,
-  response: ResponseObject
+  response: ResponseObject,
+  orchestrations?: Orchestration[]
 ): MpiMediatorResponseObject => {
   const responseBody = buildOpenhimResponseObject(
     transactionStatus,
     response.status,
-    response.body
+    response.body,
+    'application/fhir+json',
+    orchestrations
   );
 
   return {

--- a/tests/cucumber/step-definitions/fhirAccessProxy.ts
+++ b/tests/cucumber/step-definitions/fhirAccessProxy.ts
@@ -50,7 +50,7 @@ When('an $everything search request is sent', async (): Promise<void> => {
 Then(
   'a successful response containing a bundle of related patient resources is sent back',
   (): void => {
-    expect(responseBody.status).to.equal('Success');
+    expect(responseBody.status).to.equal('Successful');
     expect(JSON.parse(responseBody.response.body).resourceType).to.equal('Bundle');
     server.close();
   }
@@ -80,7 +80,7 @@ When(
 );
 
 Then('a successful response containing a bundle is sent back', (): void => {
-  expect(responseBody.status).to.equal('Success');
+  expect(responseBody.status).to.equal('Successful');
   expect(JSON.parse(responseBody.response.body).resourceType).to.equal('Bundle');
   server.close();
 });
@@ -95,6 +95,6 @@ When('an MDM search request is sent', async (): Promise<void> => {
 });
 
 Then('a successful MDM response is sent back', (): void => {
-  expect(responseBody.status).to.equal('Success');
+  expect(responseBody.status).to.equal('Successful');
   server.close();
 });

--- a/tests/cucumber/step-definitions/mpiAccessProxy.ts
+++ b/tests/cucumber/step-definitions/mpiAccessProxy.ts
@@ -70,7 +70,7 @@ When('a $match search request is sent', async (): Promise<void> => {
 });
 
 Then('a success response is sent back', (): void => {
-  expect(responseBody.status).to.equal('Success');
+  expect(responseBody.status).to.equal('Successful');
   server.close();
 });
 

--- a/tests/cucumber/step-definitions/patientSubmission.ts
+++ b/tests/cucumber/step-definitions/patientSubmission.ts
@@ -8,7 +8,6 @@ import fetch from 'node-fetch';
 
 import { getConfig } from '../../../src/config/config';
 import { getMpiAuthToken } from '../../../src/utils/mpi';
-import { response } from 'express';
 
 const app = rewire('../../../src/index').__get__('app');
 const config = getConfig();
@@ -65,7 +64,7 @@ When('a patient resource is sent to the MPI mediator', async (): Promise<void> =
   responseBody = response.body;
 });
 Then('a patient resource should be created on the client registry', (): void => {
-  expect(responseBody.status).to.equal('Success');
+  expect(responseBody.status).to.equal('Successful');
   server.close();
 });
 

--- a/tests/cucumber/step-definitions/patientSyncMatching.ts
+++ b/tests/cucumber/step-definitions/patientSyncMatching.ts
@@ -154,7 +154,7 @@ Then('an error, indicating the patient does not exist, should be sent back', ():
 Then(
   'a response, indicating the clinical data has been stored, should be sent back',
   (): void => {
-    expect(responseBody.status).to.equal('Success');
+    expect(responseBody.status).to.equal('Successful');
     sendToKafka.restore();
     server.close();
   }

--- a/tests/cucumber/step-definitions/validation.ts
+++ b/tests/cucumber/step-definitions/validation.ts
@@ -59,6 +59,6 @@ Then('an error response should be sent back', (): void => {
 });
 
 Then('a success response should be sent back', (): void => {
-  expect(responseBody.status).to.equal('Success');
+  expect(responseBody.status).to.equal('Successful');
   server.close();
 });

--- a/tests/unit/fetchPatient.ts
+++ b/tests/unit/fetchPatient.ts
@@ -137,6 +137,7 @@ describe('Fetch patient', (): void => {
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('birthDate');
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('address');
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('maritalStatus');
+      expect(result.body.orchestrations.length).to.be.equal(2);
       stub.restore();
     });
 
@@ -247,6 +248,7 @@ describe('Fetch patient', (): void => {
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('name');
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('gender');
       expect(JSON.parse(result.body.response.body)).to.haveOwnProperty('birthDate');
+      expect(result.body.orchestrations.length).to.be.equal(2);
       stub.restore();
     });
   });
@@ -462,6 +464,7 @@ describe('Fetch patient', (): void => {
 
       expect(result.status).to.be.equal(200);
       expect(JSON.parse(result.body.response.body).total).to.deep.equal(1);
+      expect(result.body.orchestrations.length).to.be.equal(3);
       stub.restore();
     });
   });

--- a/tests/unit/fetchPatientResources.ts
+++ b/tests/unit/fetchPatientResources.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Bundle } from 'fhir/r3';
 import nock from 'nock';
 import { getConfig } from '../../src/config/config';
-import { MpiMediatorResponseObject } from '../../src/types/response';
+import { MpiMediatorResponseObject, Orchestration } from '../../src/types/response';
 import {
   fetchAllPatientResourcesByRefs,
   fetchEverythingByRef,
@@ -119,8 +119,10 @@ describe('FetchPatientResources handler', (): void => {
         .get(`/fhir/Observation?subject=${encodeURIComponent(patientRef)}`)
         .reply(200, Observations);
 
-      const result = await fetchAllPatientResourcesByRefs([patientRef]);
-      expect(result).to.deep.equal(bundle);
+      const orchestrations: Orchestration[] = [];
+      const result = await fetchAllPatientResourcesByRefs([patientRef], orchestrations);
+      expect(result.total).to.be.equal(2);
+      expect(orchestrations.length).to.be.greaterThan(0);
     });
   });
   describe('*FetchPatientResources', (): void => {

--- a/tests/unit/fetchPatientSummaries.ts
+++ b/tests/unit/fetchPatientSummaries.ts
@@ -7,6 +7,7 @@ import {
   fetchPatientSummaryByRef,
 } from '../../src/routes/handlers/fetchPatientSummaries';
 import format from 'date-fns/format';
+import { Orchestration } from '../../src/types/response';
 
 const config = getConfig();
 
@@ -203,8 +204,10 @@ describe('FetchPatientSummaries handler', (): void => {
       nock(fhirDatastoreUrl).get(`/fhir/${patientRef1}/$summary`).reply(200, patientSummary1);
       nock(fhirDatastoreUrl).get(`/fhir/${patientRef2}/$summary`).reply(200, patientSummary2);
 
-      const result = await fetchAllPatientSummariesByRefs([patientRef1, patientRef2]);
+      const orchestrations: Orchestration[] = [];
+      const result = await fetchAllPatientSummariesByRefs([patientRef1, patientRef2], orchestrations);
       expect(result).to.deep.equal(combinedBundle1);
+      expect(orchestrations.length).to.be.greaterThan(0);
     });
   });
 

--- a/tests/unit/kafkaAsyncPatientHandler.ts
+++ b/tests/unit/kafkaAsyncPatientHandler.ts
@@ -53,6 +53,7 @@ describe('Kafka Async Patient Handler', (): void => {
               },
             },
             status: 'Success',
+            orchestrations: []
           },
         };
       });
@@ -118,6 +119,7 @@ describe('Kafka Async Patient Handler', (): void => {
               },
             },
             status: 'Success',
+            orchestrations: []
           },
         };
       });
@@ -208,6 +210,7 @@ describe('Kafka Async Patient Handler', (): void => {
               },
             },
             status: 'Success',
+            orchestrations: []
           },
         };
       });

--- a/tests/unit/kafkaFhir.ts
+++ b/tests/unit/kafkaFhir.ts
@@ -60,6 +60,11 @@ describe('Kafka Fhir interaction', (): void => {
 
       expect(response.status).to.be.equal(200);
       expect(response.body.status).to.be.equal('Success');
+      expect(response.body.orchestrations.length).to.be.equal(2);
+      expect(response.body.orchestrations[0].name).to.equal('Saving data in Fhir Datastore - hapi-fhir');
+      expect(response.body.orchestrations[0].response.status).to.equal(200);
+      expect(response.body.orchestrations[1].name).to.equal('Sending to message bus - kafka');
+      expect(response.body.orchestrations[1].response.status).to.equal(200);
       stub.restore();
     });
 
@@ -110,6 +115,10 @@ describe('Kafka Fhir interaction', (): void => {
 
       expect(response.status).to.be.equal(500);
       expect(response.body.status).to.be.equal('Failed');
+      expect(response.body.orchestrations[0].name).to.equal('Saving data in Fhir Datastore - hapi-fhir');
+      expect(response.body.orchestrations[0].response.status).to.equal(200);
+      expect(response.body.orchestrations[1].name).to.equal('Sending to message bus - kafka');
+      expect(response.body.orchestrations[1].response.status).to.equal(500);
       stub.restore();
     });
 

--- a/tests/unit/kafkaFhir.ts
+++ b/tests/unit/kafkaFhir.ts
@@ -59,7 +59,7 @@ describe('Kafka Fhir interaction', (): void => {
       );
 
       expect(response.status).to.be.equal(200);
-      expect(response.body.status).to.be.equal('Success');
+      expect(response.body.status).to.be.equal('Successful');
       expect(response.body.orchestrations.length).to.be.equal(2);
       expect(response.body.orchestrations[0].name).to.equal('Saving data in Fhir Datastore - hapi-fhir');
       expect(response.body.orchestrations[0].response.status).to.equal(200);
@@ -216,7 +216,7 @@ describe('Kafka Fhir interaction', (): void => {
       );
 
       expect(response.status).to.be.equal(200);
-      expect(response.body.status).to.be.equal('Success');
+      expect(response.body.status).to.be.equal('Successful');
       stub.restore();
     });
 
@@ -314,7 +314,7 @@ describe('Kafka Fhir interaction', (): void => {
       );
 
       expect(response.status).to.be.equal(200);
-      expect(response.body.status).to.be.equal('Success');
+      expect(response.body.status).to.be.equal('Successful');
       stub.restore();
     });
   });

--- a/tests/unit/matchPatientAsync.ts
+++ b/tests/unit/matchPatientAsync.ts
@@ -50,6 +50,7 @@ describe('Match Patient Asynchronously', (): void => {
 
       const response: MpiMediatorResponseObject = await matchAsyncHandler(bundle);
       expect(response.status).to.be.equal(500);
+      expect(response.body.orchestrations.length).to.be.equal(1);
       stub.restore();
     });
 

--- a/tests/unit/matchPatientSync.ts
+++ b/tests/unit/matchPatientSync.ts
@@ -108,7 +108,7 @@ describe('Match Patient Synchronously', (): void => {
             status: 200,
             body: {
               'x-mediator-urn': '123',
-              status: 'Success',
+              status: 'Successful',
               response: {
                 status: 200,
                 headers: { 'content-type': 'application/json' },
@@ -124,7 +124,7 @@ describe('Match Patient Synchronously', (): void => {
       const handlerResponse = await matchSyncHandler(bundle);
 
       expect(handlerResponse.status).to.be.equal(200);
-      expect(handlerResponse.body.status).to.be.equal('Success');
+      expect(handlerResponse.body.status).to.be.equal('Successful');
       expect(handlerResponse.body.orchestrations.length).to.equal(0);
       stub.restore();
     });
@@ -263,7 +263,7 @@ describe('Match Patient Synchronously', (): void => {
             status: 200,
             body: {
               'x-mediator-urn': '123',
-              status: 'Success',
+              status: 'Successful',
               response: {
                 status: 200,
                 headers: { 'content-type': 'application/json' },
@@ -298,7 +298,7 @@ describe('Match Patient Synchronously', (): void => {
       const handlerResponse = await matchSyncHandler(bundle);
 
       expect(handlerResponse.status).to.be.equal(200);
-      expect(handlerResponse.body.status).to.be.equal('Success');
+      expect(handlerResponse.body.status).to.be.equal('Successful');
       stub.restore();
       stub1.restore();
     });
@@ -431,7 +431,7 @@ describe('Match Patient Synchronously', (): void => {
             status: 200,
             body: {
               'x-mediator-urn': '123',
-              status: 'Success',
+              status: 'Successful',
               response: {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' },
@@ -447,7 +447,7 @@ describe('Match Patient Synchronously', (): void => {
       const handlerResponse = await matchSyncHandler(bundle);
 
       expect(handlerResponse.status).to.be.equal(200);
-      expect(handlerResponse.body.status).to.be.equal('Success');
+      expect(handlerResponse.body.status).to.be.equal('Successful');
       stub.restore();
       stub.restore();
     });

--- a/tests/unit/middlewares.ts
+++ b/tests/unit/middlewares.ts
@@ -356,6 +356,7 @@ describe('Middlewares', (): void => {
       expect(result.status).to.equal('Success');
       expect(JSON.parse(result.response.body).total).to.equal(4);
       expect(JSON.parse(result.response.body).entry.length).to.equal(4);
+      expect(result.orchestrations.length).to.be.greaterThan(0);
       nock.cleanAll();
     });
   });
@@ -418,6 +419,7 @@ describe('Middlewares', (): void => {
       expect(result.status).to.equal('Success');
       expect(JSON.parse(result.response.body).total).to.equal(2);
       expect(JSON.parse(result.response.body).entry.length).to.equal(2);
+      expect(result.orchestrations.length).to.be.greaterThan(0);
       nock.cleanAll();
     });
   });

--- a/tests/unit/middlewares.ts
+++ b/tests/unit/middlewares.ts
@@ -256,7 +256,7 @@ describe('Middlewares', (): void => {
       nock(fhirDatastoreUrl)
         .post('/fhir/Patient/$validate')
         .reply(200, {
-          status: 'Success',
+          status: 'Successful',
           body: { ...patientFhirResource1 },
         });
 
@@ -357,7 +357,7 @@ describe('Middlewares', (): void => {
       } as any as Response;
       await mpiMdmEverythingMiddleware(request, response, () => {});
       expect(statusCode).to.equal(200);
-      expect(result.status).to.equal('Success');
+      expect(result.status).to.equal('Successful');
       expect(JSON.parse(result.response.body).total).to.equal(4);
       expect(JSON.parse(result.response.body).entry.length).to.equal(4);
       expect(result.orchestrations.length).to.be.greaterThan(0);
@@ -423,7 +423,7 @@ describe('Middlewares', (): void => {
 
       await mpiMdmSummaryMiddleware(request, response, () => {});
       expect(statusCode).to.equal(200);
-      expect(result.status).to.equal('Success');
+      expect(result.status).to.equal('Successful');
       expect(JSON.parse(result.response.body).total).to.equal(2);
       expect(JSON.parse(result.response.body).entry.length).to.equal(2);
       expect(result.orchestrations.length).to.be.greaterThan(0);

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -575,7 +575,7 @@ describe('Utils', (): void => {
 
   describe('*createHandlerResponseObject', (): void => {
     it('should create handler response', (): void => {
-      const transactionStatus: string = 'Success';
+      const transactionStatus: string = 'Successful';
       const response: ResponseObject = {
         status: 200,
         body: { message: 'Success' },


### PR DESCRIPTION
This adds functionality for recording all the data orchestrations in the mpi mediator. Gives us visibility on the requests to hapi fhir, Jempi and kafka from the mediator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved orchestration tracking for API responses, enhancing visibility and traceability of data processing.

- **Bug Fixes**
  - Corrected status messages from 'Success' to 'Successful' to reflect accurate transaction states.

- **Version Updates**
  - Updated project version to `v2.3.0` for consistency across configuration files.

- **Tests**
  - Added assertions for orchestration handling in various test cases to ensure robust validation of new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->