### PR TITLE
CU-86byq7arq Fix Add docker multiplatform image build to github actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,11 +5,11 @@ on:
     tags:
       - "*.*.*"
     branches:
-      - main
+      - "*"
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM node:16
 
 WORKDIR /usr/src/app
 
-COPY node_modules ./node_modules
-COPY dist ./dist
+COPY . .
+
+RUN npm run build
+
 
 EXPOSE 3000
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to trigger on any branch and use the latest Ubuntu version.

- **Refactor**
  - Dockerfile now copies all files from the current directory and runs `npm run build` after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->